### PR TITLE
Update filters.php to fix errors

### DIFF
--- a/filters.php
+++ b/filters.php
@@ -12,6 +12,8 @@
 
 class filters extends rcube_plugin{
 
+  public $rc; /** better long term fix https://github.com/roundcubevnz/roundcube-plugin-filters/pull/3/changes#diff-32a845190b3b603fd750528baffd71709ab0627877ba794f3d4984d403d68686R17 */
+	
   public $task = 'login|mail|settings';
 
   private $autoAddSpamFilterRule;


### PR DESCRIPTION
The better fix is all the work went into here: https://github.com/roundcubevnz/roundcube-plugin-filters/pull/3/changes#diff-32a845190b3b603fd750528baffd71709ab0627877ba794f3d4984d403d68686R17

But this is just to get this one issue cleared up:
```
[07-May-2026 08:01:08 America/Los_Angeles] PHP Deprecated:  Creation of dynamic property filters::$rc is deprecated in /var/www/webmail-roundcube-0.077/plugins/filters/filters.php on line 41
[07-May-2026 08:01:11 America/Los_Angeles] PHP Deprecated:  Creation of dynamic property filters::$rc is deprecated in /var/www/webmail-roundcube-0.077/plugins/filters/filters.php on line 41
[07-May-2026 08:01:45 America/Los_Angeles] PHP Deprecated:  Creation of dynamic property filters::$rc is deprecated in /var/www/webmail-roundcube-0.077/plugins/filters/filters.php on line 41
[07-May-2026 08:01:55 America/Los_Angeles] PHP Deprecated:  Creation of dynamic property filters::$rc is deprecated in /var/www/webmail-roundcube-0.077/plugins/filters/filters.php on line 41
[07-May-2026 08:02:11 America/Los_Angeles] PHP Deprecated:  Creation of dynamic property filters::$rc is deprecated in /var/www/webmail-roundcube-0.077/plugins/filters/filters.php on line 41
[07-May-2026 08:02:37 America/Los_Angeles] PHP Deprecated:  Creation of dynamic property filters::$rc is deprecated in /var/www/webmail-roundcube-0.077/plugins/filters/filters.php on line 41
[07-May-2026 08:02:38 America/Los_Angeles] PHP Deprecated:  Creation of dynamic property filters::$rc is deprecated in /var/www/webmail-roundcube-0.077/plugins/filters/filters.php on line 41
[07-May-2026 08:02:38 America/Los_Angeles] PHP Deprecated:  Creation of dynamic property filters::$rc is deprecated in /var/www/webmail-roundcube-0.077/plugins/filters/filters.php on line 41
[07-May-2026 08:02:44 America/Los_Angeles] PHP Deprecated:  Creation of dynamic property filters::$rc is deprecated in /var/www/webmail-roundcube-0.077/plugins/filters/filters.php on line 41
[07-May-2026 08:02:45 America/Los_Angeles] PHP Deprecated:  Creation of dynamic property filters::$rc is deprecated in /var/www/webmail-roundcube-0.077/plugins/filters/filters.php on line 41
```